### PR TITLE
Fix logging side effects on import

### DIFF
--- a/src/python/cudarl/__init__.py
+++ b/src/python/cudarl/__init__.py
@@ -7,9 +7,14 @@ A high-performance reinforcement learning environment using CUDA acceleration.
 import logging
 import warnings
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Module level logger
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure basic logging for CudaRL-Arena users."""
+    logging.basicConfig(level=level)
 
 # Smart import with CUDA fallback
 try:
@@ -39,6 +44,7 @@ __all__ = [
     'Agent',
     'QTableAgent',
     'Trainer',
+    'configure_logging',
     'CUDA_AVAILABLE',
 ]
 


### PR DESCRIPTION
## Summary
- avoid configuring the root logger on import
- provide optional `configure_logging` helper

## Testing
- `python -m py_compile src/python/cudarl/__init__.py`
- `python -c "import src.python.cudarl as c; print('CUDA_AVAILABLE', c.CUDA_AVAILABLE)"`

------
https://chatgpt.com/codex/tasks/task_e_6853cfa812d4832c8e14bc20f73cc911