### PR TITLE
Fix run_training import path

### DIFF
--- a/run_training.py
+++ b/run_training.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Simple wrapper to run the training script with the mock environment."""
+
+import sys
+import os
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Create a mock cudarl_core module
+import python.cudarl.mock_env as mock_env
+sys.modules['cudarl_core'] = mock_env
+
+# Import and run the training script
+from python.scripts.train import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_training.py` wrapper script
- import `main` from `python.scripts.train`
- ensure file ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853cfa8bb70832c910d657cccf2db8d